### PR TITLE
Fixes #11

### DIFF
--- a/lib/upload.js
+++ b/lib/upload.js
@@ -214,7 +214,7 @@ Slingshot.Upload = function (directive, metaData) {
       }
 
       if (status !== "failed" && status !== "aborted" && self.file) {
-        var URL = (window.URL || window.webkitURL)
+        var URL = (window.URL || window.webkitURL);
 
         if (URL)
           return URL.createObjectURL(self.file);
@@ -230,6 +230,21 @@ Slingshot.Upload = function (directive, metaData) {
           });
         }
       }
+    },
+
+    /** Gets an upload parameter for the directive.
+     *
+     * @param {String} name
+     * @returns {String|Number|Undefined}
+     */
+
+    param: function (name) {
+      self.status(); //React to status changes.
+
+      var data = self.instructions && self.instructions.postData,
+          field = data && _.findWhere(data, {name: name});
+
+      return field && field.value;
     }
   });
 };


### PR DESCRIPTION
Added `.param()` method to `Slingshot.Upload` which can  be used to access storage service parameters such as the `key`.
