### PR TITLE
AWS Signature Version 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Default is the uploaded file's name (inline). Use null to disable.
 `AWSSecretAccessKey` String (**required**) - Can also be set in `Meteor.settings`.
 
 `region` String (optional) - Default is `Meteor.settings.AWSRegion` or
-"us-east-1".
+"us-east-1". [See AWS Regions](http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)
 
 #### Google Cloud Storage specific
 

--- a/README.md
+++ b/README.md
@@ -293,6 +293,9 @@ Default is the uploaded file's name (inline). Use null to disable.
 
 `AWSSecretAccessKey` String (**required**) - Can also be set in `Meteor.settings`.
 
+`region` String (optional) - Default is `Meteor.settings.AWSRegion` or
+"us-east-1".
+
 #### Google Cloud Storage specific
 
 `GoogleAccessId` String (**required**) - Can also be set in `Meteor.settings`.
@@ -301,9 +304,9 @@ Default is the uploaded file's name (inline). Use null to disable.
 
 ### File restrictions
 
-`authorize`: Function (optional) - Function to determines if upload is allowed.
+`authorize` Function (optional) - Function to determines if upload is allowed.
 
-`maxSize`: Number (optional) - Maximum file-size (in bytes). Use `null` or `0`
+`maxSize` Number (optional) - Maximum file-size (in bytes). Use `null` or `0`
 for unlimited.
 
 `allowedFileTypes` RegExp, String or Array (optional) - Allowed MIME types. Use

--- a/package.js
+++ b/package.js
@@ -27,3 +27,8 @@ Package.on_use(function (api) {
 
   api.export("Slingshot");
 });
+
+Package.on_test(function (api) {
+  api.use(["tinytest", "underscore", "edgee:slingshot"]);
+  api.add_files("test/aws-s3.js", "server");
+});

--- a/services/google-cloud.js
+++ b/services/google-cloud.js
@@ -6,7 +6,7 @@ Slingshot.GoogleCloud = _.defaults({
   secretKey: "GoogleSecretKey",
 
   directiveMatch: _.chain(Slingshot.S3Storage.directiveMatch)
-    .omit(Slingshot.S3Storage.accessId, Slingshot.S3Storage.secretKey)
+    .omit(Slingshot.S3Storage.accessId, Slingshot.S3Storage.secretKey, "region")
     .extend({
       GoogleAccessId: String,
       GoogleSecretKey: String,
@@ -34,8 +34,14 @@ Slingshot.GoogleCloud = _.defaults({
         return "https://" + bucket + ".storage.googleapis.com";
       }
     })
-    .omit(Slingshot.S3Storage.accessId, Slingshot.S3Storage.secretKey)
+    .omit(Slingshot.S3Storage.accessId, Slingshot.S3Storage.secretKey, "region")
     .value(),
+
+  applySignature: function (payload, policy, directive) {
+    payload[this.accessId] = directive[this.accessId];
+    payload.policy = policy.match(_.omit(payload, this.accessId)).stringify();
+    payload.signature = this.sign(directive[this.secretKey], payload.policy);
+  },
 
   /**
    * @param {String} secretKey - pem private key

--- a/test/aws-s3.js
+++ b/test/aws-s3.js
@@ -1,0 +1,23 @@
+Tinytest.add("Slingshot - AWS S3 - Signature", function (test) {
+  //http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-post-example.html
+
+  var AWSSecretAccessKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+      policy = "eyAiZXhwaXJhdGlvbiI6ICIyMDEzLTA4LTA3VDEyOjAwOjAwLjAwMFoiLA0KI" +
+        "CAiY29uZGl0aW9ucyI6IFsNCiAgICB7ImJ1Y2tldCI6ICJleGFtcGxlYnVja2V0In0sD" +
+        "QogICAgWyJzdGFydHMtd2l0aCIsICIka2V5IiwgInVzZXIvdXNlcjEvIl0sDQogICAge" +
+        "yJhY2wiOiAicHVibGljLXJlYWQifSwNCiAgICB7InN1Y2Nlc3NfYWN0aW9uX3JlZGlyZ" +
+        "WN0IjogImh0dHA6Ly9leGFtcGxlYnVja2V0LnMzLmFtYXpvbmF3cy5jb20vc3VjY2Vzc" +
+        "2Z1bF91cGxvYWQuaHRtbCJ9LA0KICAgIFsic3RhcnRzLXdpdGgiLCAiJENvbnRlbnQtV" +
+        "HlwZSIsICJpbWFnZS8iXSwNCiAgICB7IngtYW16LW1ldGEtdXVpZCI6ICIxNDM2NTEyM" +
+        "zY1MTI3NCJ9LA0KICAgIFsic3RhcnRzLXdpdGgiLCAiJHgtYW16LW1ldGEtdGFnIiwgI" +
+        "iJdLA0KDQogICAgeyJ4LWFtei1jcmVkZW50aWFsIjogIkFLSUFJT1NGT0ROTjdFWEFNU" +
+        "ExFLzIwMTMwODA2L3VzLWVhc3QtMS9zMy9hd3M0X3JlcXVlc3QifSwNCiAgICB7IngtY" +
+        "W16LWFsZ29yaXRobSI6ICJBV1M0LUhNQUMtU0hBMjU2In0sDQogICAgeyJ4LWFtei1kY" +
+        "XRlIjogIjIwMTMwODA2VDAwMDAwMFoiIH0NCiAgXQ0KfQ==";
+
+  var signature = Slingshot.S3Storage.signAwsV4(policy, AWSSecretAccessKey,
+    "20130806", "us-east-1", "s3");
+
+  test.equal(signature, "21496b44de44ccb73d545f1a995c68214c9cb0d41c45a17a5dae" +
+  "ec0b1a6db047");
+});


### PR DESCRIPTION
Fixes #33.

This adds a "region" directive parameter AWS S3, because the signatures are now constrained to a region.

The region is also used to generate the endpoint URL for the bucket dynamically to prevent preflight CORS issues.