### PR TITLE
AWS: allow dots ('.') in bucket name.

### DIFF
--- a/services/aws-s3.js
+++ b/services/aws-s3.js
@@ -48,9 +48,9 @@ Slingshot.S3Storage = {
       bucket: Meteor.settings.S3Bucket,
       bucketUrl: function (bucket, region) {
         if (region === "us-east-1")
-          return "https://" + bucket + ".s3.amazonaws.com";
+          return "https://s3.amazonaws.com";
 
-        return "https://" + bucket + ".s3-" + region + ".amazonaws.com";
+        return "https://s3-" + region + ".amazonaws.com";
       },
       region: Meteor.settings.AWSRegion || "us-east-1",
       expire: 5 * 60 * 1000 //in 5 minutes
@@ -93,13 +93,13 @@ Slingshot.S3Storage = {
           directive.bucketUrl,
 
         download = _.extend(url.parse(directive.cdn || bucketUrl), {
-          pathname: payload.key
+          pathname: directive.bucket +"/" + payload.key
         });
 
     this.applySignature(payload, policy, directive);
 
     return {
-      upload: bucketUrl,
+      upload: bucketUrl+"/"+directive.bucket,
       download: url.format(download),
       postData: [{
         name: "key",

--- a/services/aws-s3.js
+++ b/services/aws-s3.js
@@ -90,11 +90,17 @@ Slingshot.S3Storage = {
 
         bucketUrl = _.isFunction(directive.bucketUrl) ?
           directive.bucketUrl(directive.bucket, directive.region) :
-          directive.bucketUrl,
+          directive.bucketUrl
 
-        download = _.extend(url.parse(directive.cdn || bucketUrl), {
-          pathname: directive.bucket +"/" + payload.key
-        });
+        if (directive.cdn) {
+          download = _.extend(url.parse(directive.cdn), {
+            pathname: payload.key
+          });
+        } else {
+          download = _.extend(url.parse(bucketUrl), {
+            pathname: directive.bucket +"/" + payload.key
+          });
+        }
 
     this.applySignature(payload, policy, directive);
 


### PR DESCRIPTION
Previously, HTTPS certificate validation would fail if dots were
in the bucket name because the bucketURL would then contain multiple
levels of subdomains (e.g. some.depth.of.domains.s3.amazonaws.com).

Now, the bucket name is not included in the domain name, and the HTTPS
certificate is valid even when dots are in the bucket name.