### PR TITLE
AWS: allow dots ('.') in bucket name during upload.

### DIFF
--- a/services/aws-s3.js
+++ b/services/aws-s3.js
@@ -98,8 +98,12 @@ Slingshot.S3Storage = {
 
     this.applySignature(payload, policy, directive);
 
+    upload = (directive.region === "us-east-1") ?
+      "https://s3.amazonaws.com" : "https://s3-" + directive.region + ".amazonaws.com";
+    upload = upload + "/" + directive.bucket;
+
     return {
-      upload: bucketUrl,
+      upload: upload,
       download: url.format(download),
       postData: [{
         name: "key",


### PR DESCRIPTION
Previously, HTTPS certificate validation would fail if dots were in
the bucket name because the bucketURL would then contain multiple
levels of subdomains (e.g. some.depth.of.domains.s3.amazonaws.com).

Now, the bucket name is not included in the domain name during
uploads, and the HTTPS certificate is valid even when dots are in the
bucket name.

Note that this commit does not fix the situation for downloads. This
is more complicated because of multiple ways of downloading a
file. With S3 alone there is 1 (
https://bucket-name.s3[-and-possibly-region].amazonaws.com/key ) and
the approach used by this commit for uploading 2 (
https://s3[-and-possibly-region].amazonaws.com/bucket-name/key ). Then
there is with a CDN, which would typically be something like 3 (
https://cdn-distribution-name.cloudfront.net/key ). A suitable
solution to create download URLs that allows dots in the bucket name
is not covered by this commit. To word around this present limitation,
construct your own download URL using options 1, 2 and 3 according
to your needs.