### PR TITLE
#65 Meteor.userId() is only available when accounts-base package is enabled

### DIFF
--- a/lib/upload.js
+++ b/lib/upload.js
@@ -67,7 +67,7 @@ Slingshot.Upload = function (directive, metaData) {
 
     validate: function(file) {
       var context = {
-        userId: Meteor.userId()
+        userId: Meteor.userId && Meteor.userId()
       };
       try {
         var validators = Slingshot.Validators,


### PR DESCRIPTION
Fixes #65 