### PR TITLE
expose xhr in uploader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Slingshot Changelog
 ===================
 
+## Version 0.6.1
+
+### Enhancements
+
+ * Added a way to get the server response to the uploader. ([#82](https://github.com/CulturalMe/meteor-slingshot/issues/82))
+
 ## Version 0.6.0
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-meteor-slingshot 
+meteor-slingshot
 ================
 
 [![](https://api.travis-ci.org/CulturalMe/meteor-slingshot.svg)](https://travis-ci.org/CulturalMe/meteor-slingshot) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/CulturalMe/meteor-slingshot?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
@@ -38,7 +38,14 @@ On the client side we can now upload files through to the bucket:
 var uploader = new Slingshot.Upload("myFileUploads");
 
 uploader.send(document.getElementById('input').files[0], function (error, downloadUrl) {
-  Meteor.users.update(Meteor.userId(), {$push: {"profile.files": downloadUrl}});
+  if (error) {
+    // Log service detailed response
+    console.error('Error uploading', uploader.xhr.response);
+    alert (error);
+  }
+  else {
+    Meteor.users.update(Meteor.userId(), {$push: {"profile.files": downloadUrl}});
+  }
 });
 ```
 

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -56,14 +56,6 @@ Slingshot.Upload = function (directive, metaData) {
      * @returns {number}
      */
 
-    xhr: function () {
-     return self.xhr;
-    },
-
-    /**
-    * @returns {number}
-    */
-
     uploaded: function () {
       return loaded.get();
     },

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -56,6 +56,14 @@ Slingshot.Upload = function (directive, metaData) {
      * @returns {number}
      */
 
+    xhr: function () {
+     return self.xhr;
+    },
+
+    /**
+    * @returns {number}
+    */
+
     uploaded: function () {
       return loaded.get();
     },
@@ -195,6 +203,7 @@ Slingshot.Upload = function (directive, metaData) {
       });
 
       xhr.send(buildFormData());
+      self.xhr = xhr;
 
       return self;
     },

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "edgee:slingshot",
   summary: "Directly post files to cloud storage services, such as AWS-S3.",
-  version: "0.6.0",
+  version: "0.6.1",
   git: "https://github.com/CulturalMe/meteor-slingshot"
 });
 


### PR DESCRIPTION
- Simple fix for issue #82, so that `uploader.xhr.response` provides response from service.
- version bumped to 0.6.1
