### PR TITLE
Add AWS session token as optional parameter for S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,8 @@ authorization will expire after the request was made. Default is 5 minutes.
 
 `AWSSecretAccessKey` String (**required**) - Can also be set in `Meteor.settings`.
 
+`AWSSessionToken` String (optional) - Session token included in temporary security credentials.
+
 #### Google Cloud Storage
 
 `bucket` String (**required**) - Name of bucket to use. The default is

--- a/README.md
+++ b/README.md
@@ -471,8 +471,8 @@ are no arguments and the key (a string) is returned.
 `AWSSecretAccessKey` String or Function (**required**) - Can also be set in `Meteor.settings`. If it is a function,
 there are no arguments and the key (a string) is returned.
 
-`AWSSessionToken` String or Function (optional) - Session token included in temporary security credentials. If it is a
-function, there are no arguments and the token (a string) is returned.
+`AWSSessionToken` Function (optional) - Takes no arguments and returns the session token from temporary security
+credentials (a string).
 
 #### Google Cloud Storage
 

--- a/README.md
+++ b/README.md
@@ -465,11 +465,14 @@ authorization will expire after the request was made. Default is 5 minutes.
 `region` String (optional) - Default is `Meteor.settings.AWSRegion` or
 "us-east-1". [See AWS Regions](http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)
 
-`AWSAccessKeyId` String (**required**) - Can also be set in `Meteor.settings`.
+`AWSAccessKeyId` String or Function (**required**) - Can also be set in `Meteor.settings`. If it is a function, there
+are no arguments and the key (a string) is returned.
 
-`AWSSecretAccessKey` String (**required**) - Can also be set in `Meteor.settings`.
+`AWSSecretAccessKey` String or Function (**required**) - Can also be set in `Meteor.settings`. If it is a function,
+there are no arguments and the key (a string) is returned.
 
-`AWSSessionToken` String (optional) - Session token included in temporary security credentials.
+`AWSSessionToken` String or Function (optional) - Session token included in temporary security credentials. If it is a
+function, there are no arguments and the token (a string) is returned.
 
 #### Google Cloud Storage
 
@@ -512,7 +515,7 @@ Default is the uploaded file's name (inline). Use null to disable.
 
 `region` String (optional) - Data Center region. The default is `"iad3"`. [See other regions](http://docs.rackspace.com/files/api/v1/cf-devguide/content/Service-Access-Endpoints-d1e003.html)
 
-`pathPrefix` String or Function (**required**) - Simlar to `key` for S3, but will always be appended by `file.name` that is provided by the client.
+`pathPrefix` String or Function (**required**) - Similar to `key` for S3, but will always be appended by `file.name` that is provided by the client.
 
 `deleteAt` Date (optional) - Absolute time when the uploaded file is to be deleted. _This attribute is not enforced at all. It can be easily altered by the client_
 

--- a/services/aws-s3.js
+++ b/services/aws-s3.js
@@ -2,6 +2,7 @@ Slingshot.S3Storage = {
 
   accessId: "AWSAccessKeyId",
   secretKey: "AWSSecretAccessKey",
+  sessionToken: "AWSSessionToken",
 
   directiveMatch: {
     bucket: String,
@@ -15,6 +16,7 @@ Slingshot.S3Storage = {
 
     AWSAccessKeyId: String,
     AWSSecretAccessKey: String,
+    AWSSessionToken: Match.Optional(String),
 
     acl: Match.Optional(Match.Where(function (acl) {
       check(acl, String);
@@ -144,6 +146,10 @@ Slingshot.S3Storage = {
       ].join("/"),
       "x-amz-date": today + "T000000Z"
     });
+
+    if (directive[this.sessionToken]) {
+        payload["x-amz-security-token"] = directive[this.sessionToken];
+    }
 
     payload.policy = policy.match(payload).stringify();
     payload["x-amz-signature"] = this.signAwsV4(payload.policy,

--- a/services/aws-s3.js
+++ b/services/aws-s3.js
@@ -138,7 +138,8 @@ Slingshot.S3Storage = {
     _.extend(payload, {
       "x-amz-algorithm": "AWS4-HMAC-SHA256",
       "x-amz-credential": [
-        _.isFunction(directive[this.accessId]) ? directive[this.accessId]() : directive[this.accessId],
+        _.isFunction(directive[this.accessId]) ? directive[this.accessId]() :
+          directive[this.accessId],
         today,
         directive.region,
         service,
@@ -153,7 +154,8 @@ Slingshot.S3Storage = {
 
     payload.policy = policy.match(payload).stringify();
     payload["x-amz-signature"] = this.signAwsV4(payload.policy,
-      _.isFunction(directive[this.secretKey]) ? directive[this.secretKey]() : directive[this.secretKey],
+      _.isFunction(directive[this.secretKey]) ? directive[this.secretKey]() :
+        directive[this.secretKey],
       today, directive.region, service);
   },
 

--- a/services/aws-s3.js
+++ b/services/aws-s3.js
@@ -14,9 +14,9 @@ Slingshot.S3Storage = {
       return /^[a-z]{2}-\w+-\d+$/.test(region);
     }),
 
-    AWSAccessKeyId: String,
-    AWSSecretAccessKey: String,
-    AWSSessionToken: Match.Optional(String),
+    AWSAccessKeyId: Match.OneOf(String, Function),
+    AWSSecretAccessKey: Match.OneOf(String, Function),
+    AWSSessionToken: Match.Optional(Match.OneOf(String, Function)),
 
     acl: Match.Optional(Match.Where(function (acl) {
       check(acl, String);
@@ -138,7 +138,7 @@ Slingshot.S3Storage = {
     _.extend(payload, {
       "x-amz-algorithm": "AWS4-HMAC-SHA256",
       "x-amz-credential": [
-        directive[this.accessId],
+        _.isFunction(directive[this.accessId]) ? directive[this.accessId]() : directive[this.accessId],
         today,
         directive.region,
         service,
@@ -148,12 +148,14 @@ Slingshot.S3Storage = {
     });
 
     if (directive[this.sessionToken]) {
-      payload["x-amz-security-token"] = directive[this.sessionToken];
+      payload["x-amz-security-token"] = _.isFunction(directive[this.sessionToken]) ? directive[this.sessionToken]() :
+        directive[this.sessionToken];
     }
 
     payload.policy = policy.match(payload).stringify();
     payload["x-amz-signature"] = this.signAwsV4(payload.policy,
-      directive[this.secretKey], today, directive.region, service);
+      _.isFunction(directive[this.secretKey]) ? directive[this.secretKey]() : directive[this.secretKey],
+      today, directive.region, service);
   },
 
   /** Generate a AWS Signature Version 4

--- a/services/aws-s3.js
+++ b/services/aws-s3.js
@@ -148,7 +148,7 @@ Slingshot.S3Storage = {
     });
 
     if (directive[this.sessionToken]) {
-        payload["x-amz-security-token"] = directive[this.sessionToken];
+      payload["x-amz-security-token"] = directive[this.sessionToken];
     }
 
     payload.policy = policy.match(payload).stringify();

--- a/services/aws-s3.js
+++ b/services/aws-s3.js
@@ -16,7 +16,7 @@ Slingshot.S3Storage = {
 
     AWSAccessKeyId: Match.OneOf(String, Function),
     AWSSecretAccessKey: Match.OneOf(String, Function),
-    AWSSessionToken: Match.Optional(Match.OneOf(String, Function)),
+    AWSSessionToken: Match.Optional(Function),
 
     acl: Match.Optional(Match.Where(function (acl) {
       check(acl, String);
@@ -148,8 +148,7 @@ Slingshot.S3Storage = {
     });
 
     if (directive[this.sessionToken]) {
-      payload["x-amz-security-token"] = _.isFunction(directive[this.sessionToken]) ? directive[this.sessionToken]() :
-        directive[this.sessionToken];
+      payload["x-amz-security-token"] = directive[this.sessionToken]();
     }
 
     payload.policy = policy.match(payload).stringify();


### PR DESCRIPTION
If using temporary security credentials, for example when on an EC2 instance with IAM role policies setting S3 access, requests need to include the session token.