### PR TITLE
Update bucket domain for AWS beijing region.

### DIFF
--- a/services/aws-s3.js
+++ b/services/aws-s3.js
@@ -50,6 +50,8 @@ Slingshot.S3Storage = {
         var bucketDomain = "s3-" + region + ".amazonaws.com";
         if (region === "us-east-1")
           bucketDomain = "s3.amazonaws.com";
+        if (region === "cn-north-1")
+          bucketDomain = "s3.cn-north-1.amazonaws.com.cn";
 
         if (bucket.indexOf(".") !== -1)
           return "https://" + bucketDomain + "/" + bucket;


### PR DESCRIPTION
According to AWS's doc: <http://docs.amazonaws.cn/en_us/aws/latest/userguide/s3.html>, the endpoints for services in the Beijing region are different from other global endpoints.