### PR TITLE
Support custom file names

### DIFF
--- a/lib/upload.js
+++ b/lib/upload.js
@@ -29,7 +29,7 @@ Slingshot.Upload = function (directive, metaData) {
       formData.append(field.name, field.value);
     });
 
-    formData.append("file", self.file);
+    formData.append("file", self.file, self.file.name);
 
     return formData;
   }


### PR DESCRIPTION
I was working on an application which dynamically creates blobs (using the Blob constructor) and uploads them to Rackspace. Unfortunately blobs are uploaded as "blob" when no filename is specified in `formData.append()`, so I made this minor change allowing users to rename their blobs before upload. One alternative is to use the File constructor instead but it is not supported by nearly as many browsers. I haven't tested it with actual files but it shouldn't change the current behaviour and may allow renaming the files if need be.

**Example**
    var myBlob = new Blob([...]);
    myBlob.name = "myImage.jpg";

Thanks for creating this excellent package!
