### PR TITLE
Updating deprecated 'new Buffer()' to 'Buffer.from()'

### DIFF
--- a/lib/storage-policy.js
+++ b/lib/storage-policy.js
@@ -101,9 +101,8 @@ Slingshot.StoragePolicy = function () {
 
     stringify: function (encoding) {
       /* global Buffer: false */
-      return Buffer(JSON.stringify(policy), "utf-8")
+      return Buffer.from(JSON.stringify(policy), "utf-8")
         .toString(encoding || "base64");
     }
   });
 };
-

--- a/services/aws-s3.js
+++ b/services/aws-s3.js
@@ -230,6 +230,6 @@ function hmac256(key, data, encoding) {
   /* global Buffer: false */
   return crypto
     .createHmac("sha256", key)
-    .update(new Buffer(data, "utf-8"))
+    .update(Buffer.from(data, "utf-8"))
     .digest(encoding);
 }

--- a/services/rackspace.js
+++ b/services/rackspace.js
@@ -106,7 +106,7 @@ Slingshot.RackspaceFiles = {
 
     return Npm.require("crypto")
       .createHmac("sha1", secretkey)
-      .update(new Buffer(policy, "utf-8"))
+      .update(Buffer.from(policy, "utf-8"))
       .digest("hex");
   }
 


### PR DESCRIPTION
**Updating** Buffer() that is deprecated and generating the following warning:

> `(node:15707) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.`

The solution was replace the `new Buffer()` lines for `Buffer.from()` as recommended.